### PR TITLE
Update ReziApiService.php

### DIFF
--- a/src/services/ReziApiService.php
+++ b/src/services/ReziApiService.php
@@ -139,7 +139,7 @@ class ReziApiService extends Component
         CURLOPT_TIMEOUT => 30,
         CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
         CURLOPT_CUSTOMREQUEST => "POST",
-        CURLOPT_POSTFIELDS => "{\n  MinimumPrice: 0,\n  MaximumPrice:1000000,\n  MinimumBedrooms:0,\n  MaximumBedrooms:10,\n  BranchIdList:[],\n  PageNumber: ".$pageNumber.",\n PageSize: 20,\n MarketingFlags: ['ApprovedForMarketingWebsite'] }",
+        CURLOPT_POSTFIELDS => "{\n  MinimumPrice: 0,\n  MinimumBedrooms:0,\n  BranchIdList:[],\n  PageNumber: ".$pageNumber.",\n PageSize: 20,\n MarketingFlags: ['ApprovedForMarketingWebsite'] }",
         CURLOPT_HTTPHEADER => array(
             "Cache-Control: no-cache",
             "Content-Type: application/json",


### PR DESCRIPTION
Fixes issue with properties not being bought in if they are above £1,000,000. Filtering of max pricing of properties should be done on full set of results, not on prior to result retrieval